### PR TITLE
Draft: Tomato's sample and payload schema.

### DIFF
--- a/src/dgbowl_schemas/tomato_payload/dummy.py
+++ b/src/dgbowl_schemas/tomato_payload/dummy.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Extra
+from typing import Literal, Union
+
+class Random(BaseModel, extra = Extra.forbid):
+    name: Literal["random"]
+    delay: float = 1.0
+    time: float = 10.0
+
+class Sequential(BaseModel, extra = Extra.forbid):
+    name: str
+    delay: float = 1.0
+    time: float = 10.0
+
+DummyPayloads = Union[Random, Sequential]

--- a/src/dgbowl_schemas/tomato_payload/electrochem.py
+++ b/src/dgbowl_schemas/tomato_payload/electrochem.py
@@ -1,8 +1,21 @@
 from pydantic import BaseModel, Extra
 from typing import Literal, Union
 
+allowed_I_ranges = Literal[
+    "keep", "100 pA", "1 nA", "10 nA", "100 nA", "1 uA", "10 uA", "100 uA",
+    "1 mA", "10 mA", "100 mA", "1 A", "booster", "auto",
+]
+allowed_E_ranges = Literal[
+    "+-2.5 V", "+-5.0 V", "+-10 V", "auto",
+]
+
 class OpenCircuitVoltage(BaseModel, extra = Extra.forbid):
     name: Literal["open_circuit_voltage"]
+    time: float = 0.0
+    record_every_dt: float = 30.0
+    record_every_dE: float = 0.005
+    I_range: allowed_I_ranges = "keep"
+    E_range: allowed_E_ranges = "auto"
 
 class ConstantVoltage(BaseModel, extra = Extra.forbid):
     name: Literal["constant_voltage"]
@@ -18,6 +31,8 @@ class SweepCurrent(BaseModel, extra = Extra.forbid):
 
 class Loop(BaseModel, extra = Extra.forbid):
     name: Literal["loop"]
+    n_gotos: int = -1
+    goto: int = 0
 
 ElectroChemPayloads = Union[
     OpenCircuitVoltage,

--- a/src/dgbowl_schemas/tomato_payload/electrochem.py
+++ b/src/dgbowl_schemas/tomato_payload/electrochem.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, Extra
+from typing import Literal, Union
+
+class OpenCircuitVoltage(BaseModel, extra = Extra.forbid):
+    name: Literal["open_circuit_voltage"]
+
+class ConstantVoltage(BaseModel, extra = Extra.forbid):
+    name: Literal["constant_voltage"]
+
+class ConstantCurrent(BaseModel, extra = Extra.forbid):
+    name: Literal["constant_current"]
+
+class SweepVoltage(BaseModel, extra = Extra.forbid):
+    name: Literal["sweep_voltage"]
+
+class SweepCurrent(BaseModel, extra = Extra.forbid):
+    name: Literal["sweep_current"]
+
+class Loop(BaseModel, extra = Extra.forbid):
+    name: Literal["loop"]
+
+ElectroChemPayloads = Union[
+    OpenCircuitVoltage,
+    ConstantCurrent,
+    ConstantVoltage,
+    SweepCurrent,
+    SweepVoltage,
+    Loop,
+]

--- a/src/dgbowl_schemas/tomato_payload/sample.py
+++ b/src/dgbowl_schemas/tomato_payload/sample.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, Extra
+from typing import Literal, Mapping
+
+class BatterySample(BaseModel, extra = Extra.forbid):
+
+    class Capacity(BaseModel, extra = Extra.forbid):
+        nominal: float
+        actual: float
+
+    name: str
+    type: Literal["battery"]
+    capacity: Capacity
+
+
+class Sample(BaseModel, extra = Extra.allow):
+    name: str
+    type: str
+
+
+    

--- a/src/dgbowl_schemas/tomato_payload/schema.py
+++ b/src/dgbowl_schemas/tomato_payload/schema.py
@@ -4,7 +4,8 @@ import json
 import yaml
 
 from .sample import BatterySample, Sample
-from .biologic import BiologicPayloads
+from .electrochem import ElectroChemPayloads
+from .dummy import DummyPayloads
 
 class Payload(BaseModel, extra = Extra.forbid):
     version: Literal["0.1"]
@@ -13,7 +14,7 @@ class Payload(BaseModel, extra = Extra.forbid):
         Sample
     ] = Field(..., discriminator = "type")
     payload: Sequence[
-        BiologicPayloads, 
+        ElectroChemPayloads, 
         DummyPayloads
     ] = Field(..., discriminator = "name")
 

--- a/src/dgbowl_schemas/tomato_payload/schema.py
+++ b/src/dgbowl_schemas/tomato_payload/schema.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, Extra, Field, root_validator
+from typing import Literal, Union, Sequence
+import json
+import yaml
+
+from .sample import BatterySample, Sample
+from .biologic import BiologicPayloads
+
+class Payload(BaseModel, extra = Extra.forbid):
+    version: Literal["0.1"]
+    sample: Union[
+        BatterySample, 
+        Sample
+    ] = Field(..., discriminator = "type")
+    payload: Sequence[
+        BiologicPayloads, 
+        DummyPayloads
+    ] = Field(..., discriminator = "name")
+
+    @root_validator(pre=True)
+    def check_for_files(cls, values):
+        for key in ["sample", "payload"]:
+            exclusive = {key, f"{key}file"}
+            assert len(exclusive.intersection(values)) == 1, (
+                "multiple keys provided: " f"{exclusive.intersection(values)}"
+            )
+            if key in values:
+                continue
+            else:
+                fn = values.pop(f"{key}file")
+                with open(fn, "r") as infile:
+                    if fn.endswith("json"):
+                        data = json.load(infile)
+                    elif fn.endswith("yml") or fn.endswith("yaml"):
+                        data = yaml.safe_load(infile)
+                values[key] = data
+        return values


### PR DESCRIPTION
This PR will implement the payload and sample schema for tomato:

- [x] `BatterySample` implemented with nominal (recipe) and actual (material) capacities
- [ ] `ElectroChemPayloads` implemented, including `OpenCircuitVoltage`, `ConstantCurrent`, `ConstantVoltage`, `Loop`, `SweepCurrent`, and `SweepVoltage`
- [x] `DummyPayloads` implemented, including `Random` and `Sequential`
- [ ] Documentation
- [ ] Tests

@lorisercole, comments here are welcome.