### PR TITLE
Add `update` functionality to dgbowl-schemas.

### DIFF
--- a/src/dgbowl_schemas/yadg/dataschema_4_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_0/__init__.py
@@ -2,8 +2,46 @@ from pydantic import BaseModel, Extra
 from typing import Sequence
 from .metadata import Metadata
 from .step import Steps
+import logging
+
+from ..dataschema_4_1 import DataSchema as NewDataSchema
+
+logger = logging.getLogger(__name__)
 
 
 class DataSchema(BaseModel, extra=Extra.forbid):
     metadata: Metadata
     steps: Sequence[Steps]
+
+    def update(self):
+        logger.info("Updating from DataSchema-4.0 to DataSchema-4.1")
+
+        nsch = {"metadata": {}, "steps": []}
+        nsch["metadata"] = {
+            "version": "4.1",
+            "timezone": self.metadata.timezone,
+            "provenance": {
+                "type": self.metadata.provenance,
+                "metadata": {
+                    "updated-using": "dgbowl-schemas",
+                    "from": self.metadata.version,
+                },
+            },
+        }
+        for step in self.steps:
+            nstep = {
+                "parser": step.parser,
+                "tag": step.tag,
+                "input": step.input.dict(exclude_none=True),
+            }
+            if step.externaldate is not None:
+                nstep["externaldate"] = step.externaldate.dict(exclude_none=True)
+            if step.parameters is not None:
+                nstep["parameters"] = step.parameters.dict(exclude_none=True)
+                if "tracetype" in nstep["parameters"]:
+                    nstep["parameters"]["filetype"] = nstep["parameters"]["tracetype"]
+                    del nstep["parameters"]["tracetype"]
+
+            nsch["steps"].append(nstep)
+
+        return NewDataSchema(**nsch)

--- a/src/dgbowl_schemas/yadg/dataschema_4_1/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_1/__init__.py
@@ -2,8 +2,42 @@ from pydantic import BaseModel, Extra
 from typing import Sequence
 from .metadata import Metadata
 from .step import Steps
+import logging
+
+from ..dataschema_4_2 import DataSchema as NewDataSchema
+
+logger = logging.getLogger(__name__)
 
 
 class DataSchema(BaseModel, extra=Extra.forbid):
     metadata: Metadata
     steps: Sequence[Steps]
+
+    def update(self):
+        logger.info("Updating from DataSchema-4.1 to DataSchema-4.2")
+
+        nsch = {"metadata": {}, "steps": []}
+        nsch["metadata"] = {
+            "version": "4.2",
+            "timezone": self.metadata.timezone,
+            "provenance": self.metadata.provenance.dict(exclude_none=True),
+        }
+        if "metadata" not in nsch["metadata"]["provenance"]:
+            nsch["metadata"]["provenance"]["metadata"] = {
+                "updated-using": "dgbowl-schemas",
+                "from": self.metadata.version,
+            }
+        for step in self.steps:
+            nstep = {
+                "parser": step.parser,
+                "tag": step.tag,
+                "input": step.input.dict(exclude_none=True),
+            }
+            if step.externaldate is not None:
+                nstep["externaldate"] = step.externaldate.dict(exclude_none=True)
+            if step.parameters is not None:
+                nstep["parameters"] = step.parameters.dict(exclude_none=True)
+
+            nsch["steps"].append(nstep)
+
+        return NewDataSchema(**nsch)

--- a/src/dgbowl_schemas/yadg/dataschema_4_2/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_2/__init__.py
@@ -2,6 +2,11 @@ from pydantic import BaseModel, Extra
 from typing import Sequence
 from .metadata import Metadata
 from .step import Steps
+import logging
+
+from ..dataschema_5_0 import DataSchema as NewDataSchema
+
+logger = logging.getLogger(__name__)
 
 
 class DataSchema(BaseModel, extra=Extra.forbid):
@@ -10,3 +15,61 @@ class DataSchema(BaseModel, extra=Extra.forbid):
 
     steps: Sequence[Steps]
     """A sequence of parser steps."""
+
+    def update(self):
+        logger.info("Updating from DataSchema-4.2 to DataSchema-5.0")
+
+        nsch = {"metadata": {}, "steps": []}
+        nsch["metadata"] = {
+            "version": "5.0",
+            "timezone": self.metadata.timezone,
+            "provenance": self.metadata.provenance.dict(exclude_none=True),
+        }
+        if "metadata" not in nsch["metadata"]["provenance"]:
+            nsch["metadata"]["provenance"]["metadata"] = {
+                "updated-using": "dgbowl-schemas",
+                "from": self.metadata.version,
+            }
+        for step in self.steps:
+            nstep = {
+                "parser": step.parser,
+                "tag": step.tag,
+                "input": step.input.dict(exclude_none=True),
+            }
+            if step.externaldate is not None:
+                nstep["externaldate"] = step.externaldate.dict(exclude_none=True)
+            if step.parameters is not None:
+                nstep["parameters"] = step.parameters.dict(exclude_none=True)
+            else:
+                nstep["parameters"] = {}
+
+            if "filetype" in nstep["parameters"]:
+                nstep["filetype"] = nstep["parameters"].pop("filetype")
+
+            for k in {
+                "sigma",
+                "calfile",
+                "convert",
+                "species",
+                "detectors",
+                "method",
+                "height",
+                "distance",
+                "cutoff",
+                "threshold",
+            }:
+                if k in nstep["parameters"]:
+                    logger.warning(
+                        "Parameter '%s' of parser '%s' is not "
+                        "supported in DataSchema-5.0.",
+                        k,
+                        nstep["parser"],
+                    )
+                    del nstep["parameters"][k]
+
+            if nstep["parameters"] == {}:
+                del nstep["parameters"]
+
+            nsch["steps"].append(nstep)
+
+        return NewDataSchema(**nsch)

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -77,3 +77,39 @@ def test_dataschema_err(inpath, datadir):
     with pytest.raises(ValueError) as e:
         to_dataschema(**jsdata["input"])
     assert jsdata["exception"] in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "inpath",
+    [
+        ("up0_chromtrace.json"),  # 4.0
+        ("up1_chromtrace.json"),  # 4.1
+        ("up2_chromtrace.json"),  # 4.2
+        ("up3_chromdata.json"),  # 4.2
+    ],
+)
+def test_dataschema_update(inpath, datadir):
+    os.chdir(datadir)
+    with open(inpath, "r") as infile:
+        jsdata = json.load(infile)
+    ref = jsdata["output"]
+    ret = to_dataschema(**jsdata["input"]).update()
+    assert ref == ret.dict(exclude_none=True)
+
+
+@pytest.mark.parametrize(
+    "inpath",
+    [
+        ("chain_vna_4.0.json"),  # 4.0
+        ("chain_gc_4.0.json"),  # 4.0
+        ("chain_basiccsv_4.1.json"),  # 4.1
+    ],
+)
+def test_dataschema_update_chain(inpath, datadir):
+    os.chdir(datadir)
+    with open(inpath, "r") as infile:
+        jsdata = json.load(infile)
+    ret = to_dataschema(**jsdata)
+    while hasattr(ret, "update"):
+        ret = ret.update()
+    assert ret.metadata.version == "5.0"

--- a/tests/test_dataschema/chain_basiccsv_4.1.json
+++ b/tests/test_dataschema/chain_basiccsv_4.1.json
@@ -1,0 +1,20 @@
+{
+    "metadata": {
+        "provenance": {"type": "manual"},
+        "version": "4.1"
+    },
+    "steps": [
+        {
+            "parser": "basiccsv",
+            "input": {
+                "folders": ["data/agilentcsv/"],
+                "suffix": "csv"
+            },
+            "parameters": {
+                "sep": ";",
+                "sigma": {"col": {"atol": 1e-4}}
+            }
+        }
+
+    ]
+}

--- a/tests/test_dataschema/chain_gc_4.0.json
+++ b/tests/test_dataschema/chain_gc_4.0.json
@@ -1,0 +1,20 @@
+{
+    "metadata": {
+        "provenance": "manual",
+        "schema_version": "4.0.0"
+    },
+    "steps": [
+        {
+            "parser": "chromtrace",
+            "import": {
+                "folders": ["data/agilentcsv/"],
+                "prefix": "2019"
+                
+            },
+            "parameters": {
+                "tracetype": "ezchrom.asc",
+                "calfile": "calibrations/gccal.json"
+            }
+        }
+    ]
+}

--- a/tests/test_dataschema/chain_vna_4.0.json
+++ b/tests/test_dataschema/chain_vna_4.0.json
@@ -1,0 +1,18 @@
+{
+    "metadata": {
+        "provenance": "manual",
+        "schema_version": "4.0.0"
+    },
+    "steps": [
+        {
+            "parser": "qftrace",
+            "import": {
+                "folders": ["data/vna/"]
+            },
+            "parameters": {
+                "method": "kajfez",
+                "cutoff": 0.4
+            }
+        }
+    ]
+}

--- a/tests/test_dataschema/up0_chromtrace.json
+++ b/tests/test_dataschema/up0_chromtrace.json
@@ -1,0 +1,37 @@
+{
+    "input": {
+        "metadata": {
+            "provenance": "up0_chromtrace.json",
+            "schema_version": "4.0"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "import": {"files": ["file.dat"]},
+                "parameters": {"tracetype": "ezchrom.asc"}
+            }
+        ]
+    },
+    "output": {
+        "metadata": {
+            "provenance": {
+                "type": "up0_chromtrace.json",
+                "metadata": {"updated-using": "dgbowl-schemas", "from": "4.0"}
+            },
+            "version": "4.1",
+            "timezone": "localtime"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "input": {
+                    "files": ["file.dat"],
+                    "encoding": "UTF-8"
+                },
+                "parameters": {
+                    "filetype": "ezchrom.asc"
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_dataschema/up1_chromtrace.json
+++ b/tests/test_dataschema/up1_chromtrace.json
@@ -1,0 +1,38 @@
+{
+    "input": {
+        "metadata": {
+            "provenance": {"type": "up1_chromtrace.json"},
+            "version": "4.1",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "input": {"files": ["file.dat"]},
+                "parameters": {"filetype": "ezchrom.asc"}
+            }
+        ]
+    },
+    "output": {
+        "metadata": {
+            "provenance": {
+                "type": "up1_chromtrace.json",
+                "metadata": {"updated-using": "dgbowl-schemas", "from": "4.1"}
+            },
+            "version": "4.2",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "input": {
+                    "files": ["file.dat"],
+                    "encoding": "UTF-8"
+                },
+                "parameters": {
+                    "filetype": "ezchrom.asc"
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_dataschema/up2_chromtrace.json
+++ b/tests/test_dataschema/up2_chromtrace.json
@@ -1,0 +1,36 @@
+{
+    "input": {
+        "metadata": {
+            "provenance": {"type": "up2_chromtrace.json"},
+            "version": "4.2",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "input": {"files": ["file.dat"]},
+                "parameters": {"filetype": "ezchrom.asc", "calfile": "caldata.json"}
+            }
+        ]
+    },
+    "output": {
+        "metadata": {
+            "provenance": {
+                "type": "up2_chromtrace.json",
+                "metadata": {"updated-using": "dgbowl-schemas", "from": "4.2"}
+            },
+            "version": "5.0",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromtrace",
+                "input": {
+                    "files": ["file.dat"],
+                    "encoding": "UTF-8"
+                },
+                "filetype": "ezchrom.asc"
+            }
+        ]
+    }
+}

--- a/tests/test_dataschema/up3_chromdata.json
+++ b/tests/test_dataschema/up3_chromdata.json
@@ -1,0 +1,36 @@
+{
+    "input": {
+        "metadata": {
+            "provenance": {"type": "up3_chromdata.json"},
+            "version": "4.2",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromdata",
+                "input": {"files": ["file.dat"]},
+                "parameters": {"filetype": "empalc.csv"}
+            }
+        ]
+    },
+    "output": {
+        "metadata": {
+            "provenance": {
+                "type": "up3_chromdata.json",
+                "metadata": {"updated-using": "dgbowl-schemas", "from": "4.2"}
+            },
+            "version": "5.0",
+            "timezone": "Europe/Berlin"
+        },
+        "steps": [
+            {
+                "parser": "chromdata",
+                "input": {
+                    "files": ["file.dat"],
+                    "encoding": "UTF-8"
+                },
+                "filetype": "empalc.csv"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
All older version of `DataSchema` now have an `.update()` function, which returns the current `schema` parsed through a newer `DataSchema` version than the current one.

If the returned `schema` does not have the `.update()` function/attr, it can be assumed to be the up-to-date version.