### PR TITLE
`DataSchema`: Implement `FileTypeFactory` and extend FileTypes

### DIFF
--- a/.github/workflows/lint-every-pr.yml
+++ b/.github/workflows/lint-every-pr.yml
@@ -18,4 +18,3 @@ jobs:
          VALIDATE_PYTHON_BLACK: true
          VALIDATE_PYTHON_FLAKE8: true
          VALIDATE_PYTHON_PYLINT: true
-         VALIDATE_PYTHON_MYPY: true

--- a/.github/workflows/lint-every-pr.yml
+++ b/.github/workflows/lint-every-pr.yml
@@ -18,3 +18,4 @@ jobs:
          VALIDATE_PYTHON_BLACK: true
          VALIDATE_PYTHON_FLAKE8: true
          VALIDATE_PYTHON_PYLINT: true
+         VALIDATE_PYTHON_MYPY: true

--- a/src/dgbowl_schemas/__init__.py
+++ b/src/dgbowl_schemas/__init__.py
@@ -1,12 +1,12 @@
 from .dgpost import Recipe, to_recipe
 from .tomato import Payload, to_payload
-from .yadg import DataSchema, FileTypes, to_dataschema
+from .yadg import DataSchema, FileTypeFactory, to_dataschema
 
 __all__ = [
     "Recipe",
     "Payload",
     "DataSchema",
-    "FileTypes",
+    "FileTypeFactory",
     "to_recipe",
     "to_payload",
     "to_dataschema",

--- a/src/dgbowl_schemas/__init__.py
+++ b/src/dgbowl_schemas/__init__.py
@@ -1,12 +1,11 @@
 from .dgpost import Recipe, to_recipe
 from .tomato import Payload, to_payload
-from .yadg import DataSchema, FileTypeFactory, to_dataschema
+from .yadg import DataSchema, to_dataschema
 
 __all__ = [
     "Recipe",
     "Payload",
     "DataSchema",
-    "FileTypeFactory",
     "to_recipe",
     "to_payload",
     "to_dataschema",

--- a/src/dgbowl_schemas/yadg/__init__.py
+++ b/src/dgbowl_schemas/yadg/__init__.py
@@ -1,6 +1,6 @@
 from pydantic import ValidationError
 import logging
-from .dataschema_5_0.filetype import FileTypes as FileTypes_5_0
+from .dataschema_5_0.filetype import FileTypeFactory as FileTypeFactory_5_0
 from .dataschema_5_0 import DataSchema as DataSchema_5_0, Metadata as Metadata_5_0
 from .dataschema_4_2 import DataSchema as DataSchema_4_2, Metadata as Metadata_4_2
 from .dataschema_4_1 import DataSchema as DataSchema_4_1, Metadata as Metadata_4_1
@@ -10,7 +10,7 @@ from .dataschema_4_0 import DataSchema as DataSchema_4_0, Metadata as Metadata_4
 logger = logging.getLogger(__name__)
 
 DataSchema = DataSchema_5_0
-FileTypes = FileTypes_5_0
+FileTypeFactory = FileTypeFactory_5_0
 
 models = {
     "5.0": (DataSchema_5_0, Metadata_5_0),

--- a/src/dgbowl_schemas/yadg/__init__.py
+++ b/src/dgbowl_schemas/yadg/__init__.py
@@ -1,7 +1,7 @@
 from pydantic import ValidationError
 import logging
 from .dataschema_5_0 import (
-    DataSchema as DataSchema_5_0, 
+    DataSchema as DataSchema_5_0,
     Metadata as Metadata_5_0,
     FileType as FileType_5_0,
     FileTypeFactory as FileTypeFactory_5_0,

--- a/src/dgbowl_schemas/yadg/__init__.py
+++ b/src/dgbowl_schemas/yadg/__init__.py
@@ -1,7 +1,11 @@
 from pydantic import ValidationError
 import logging
-from .dataschema_5_0.filetype import FileTypeFactory as FileTypeFactory_5_0
-from .dataschema_5_0 import DataSchema as DataSchema_5_0, Metadata as Metadata_5_0
+from .dataschema_5_0 import (
+    DataSchema as DataSchema_5_0, 
+    Metadata as Metadata_5_0,
+    FileType as FileType_5_0,
+    FileTypeFactory as FileTypeFactory_5_0,
+)
 from .dataschema_4_2 import DataSchema as DataSchema_4_2, Metadata as Metadata_4_2
 from .dataschema_4_1 import DataSchema as DataSchema_4_1, Metadata as Metadata_4_1
 from .dataschema_4_0 import DataSchema as DataSchema_4_0, Metadata as Metadata_4_0
@@ -10,6 +14,8 @@ from .dataschema_4_0 import DataSchema as DataSchema_4_0, Metadata as Metadata_4
 logger = logging.getLogger(__name__)
 
 DataSchema = DataSchema_5_0
+Metadata = Metadata_5_0
+FileType = FileType_5_0
 FileTypeFactory = FileTypeFactory_5_0
 
 models = {

--- a/src/dgbowl_schemas/yadg/dataschema_4_2/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_2/__init__.py
@@ -37,8 +37,6 @@ class DataSchema(BaseModel, extra=Extra.forbid):
                 "tag": step.tag,
                 "input": step.input.dict(exclude_none=True),
             }
-            if "encoding" in nstep["input"]:
-                nstep["encoding"] = nstep["input"].pop("encoding")
             if step.externaldate is not None:
                 nstep["externaldate"] = step.externaldate.dict(exclude_none=True)
             if step.parameters is not None:
@@ -46,8 +44,13 @@ class DataSchema(BaseModel, extra=Extra.forbid):
             else:
                 nstep["parameters"] = {}
 
-            if "filetype" in nstep["parameters"]:
-                nstep["filetype"] = nstep["parameters"].pop("filetype")
+            extractor = {}
+            if nstep["parameters"].get("filetype", None) is not None:
+                extractor["filetype"] = nstep["parameters"].pop("filetype")
+            if nstep["input"].get("encoding", None) is not None:
+                extractor["encoding"] = nstep["input"].pop("encoding")
+            if len(extractor) > 0:
+                nstep["extractor"] = extractor
 
             for k in {
                 "sigma",

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -3,7 +3,7 @@ from typing import Sequence
 from .metadata import Metadata
 from .step import Steps
 from .stepdefaults import StepDefaults
-
+from .filetype import FileTypeFactory, FileType
 
 class DataSchema(BaseModel, extra=Extra.forbid):
     """
@@ -18,3 +18,5 @@ class DataSchema(BaseModel, extra=Extra.forbid):
 
     steps: Sequence[Steps]
     """Input commands for ``yadg``'s parsers, organised as a sequence of steps."""
+
+__all__ = ["DataSchema", "Metadata", "FileType", "FileTypeFactory"]

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -5,6 +5,7 @@ from .step import Steps
 from .stepdefaults import StepDefaults
 from .filetype import FileTypeFactory, FileType
 
+
 class DataSchema(BaseModel, extra=Extra.forbid):
     """
     :class:`DataSchema` introduced in ``yadg-5.0``.
@@ -18,5 +19,6 @@ class DataSchema(BaseModel, extra=Extra.forbid):
 
     steps: Sequence[Steps]
     """Input commands for ``yadg``'s parsers, organised as a sequence of steps."""
+
 
 __all__ = ["DataSchema", "Metadata", "FileType", "FileTypeFactory"]

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -32,11 +32,23 @@ class NoFileType(FileType):
     filetype: Optional[None] = None
 
 
-class Drycal_any(FileType):
-    filetype: Literal["drycal.csv", "drycal.rtf", "drycal.txt"]
+class Drycal_csv(FileType):
+    filetype: Literal["drycal.csv"]
 
 
-FlowDataFileTypes = Drycal_any
+class Drycal_rtf(FileType):
+    filetype: Literal["drycal.rtf"]
+
+
+class Drycal_txt(FileType):
+    filetype: Literal["drycal.txt"]
+
+
+FlowDataFileTypes = Union[
+    Drycal_csv,
+    Drycal_rtf,
+    Drycal_txt,
+]
 
 
 class EClab_mpr(FileType):
@@ -87,8 +99,12 @@ class Agilent_csv(FileType):
     filetype: Literal["agilent.csv"]
 
 
-class EmpaLC_any(FileType):
-    filetype: Literal["empalc.csv", "empalc.xlsx"]
+class EmpaLC_csv(FileType):
+    filetype: Literal["empalc.csv"]
+
+
+class EmpaLC_xlsx(FileType):
+    filetype: Literal["empalc.xlsx"]
 
 
 ChromTraceFileTypes = Union[
@@ -104,7 +120,8 @@ ChromDataFileTypes = Union[
     Fusion_json,
     Fusion_zip,
     Fusion_csv,
-    EmpaLC_any,
+    EmpaLC_csv,
+    EmpaLC_xlsx,
 ]
 
 
@@ -152,5 +169,4 @@ class FileTypeFactory(BaseModel):
     filetype: Union[
         EClab_mpr,
         EClab_mpt,
-        Tomato_json,
     ] = Field(..., discriminator="filetype")

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -8,8 +8,8 @@ import locale
 class FileType(BaseModel, ABC, extra=Extra.forbid):
     """Template ABC for parser classes."""
 
-    filetype: str
-    timezone: str = "localtime"
+    filetype: Optional[str]
+    timezone: Optional[str]
     locale: Optional[str]
     encoding: Optional[str]
 
@@ -23,9 +23,20 @@ class FileType(BaseModel, ABC, extra=Extra.forbid):
     @validator("locale", always=True)
     @classmethod
     def locale_set_default(cls, v):
-        if v is None:
+        if v == "getlocale":
             v = ".".join(locale.getlocale())
         return v
+
+
+class NoFileType(FileType):
+    filetype: Optional[None] = None
+
+
+class Drycal_any(FileType):
+    filetype: Literal["drycal.csv", "drycal.rtf", "drycal.txt"]
+
+
+FlowDataFileTypes = Drycal_any
 
 
 class EClab_mpr(FileType):
@@ -39,6 +50,102 @@ class EClab_mpt(FileType):
 
 class Tomato_json(FileType):
     filetype: Literal["tomato.json"]
+
+
+ElectroChemFileTypes = Union[
+    EClab_mpr,
+    EClab_mpt,
+    Tomato_json,
+]
+
+
+class EZChrom_asc(FileType):
+    filetype: Literal["ezchrom.asc"]
+
+
+class Fusion_json(FileType):
+    filetype: Literal["fusion.json"]
+
+
+class Fusion_zip(FileType):
+    filetype: Literal["fusion.zip"]
+
+
+class Fusion_csv(FileType):
+    filetype: Literal["fusion.csv"]
+
+
+class Agilent_ch(FileType):
+    filetype: Literal["agilent.ch"]
+
+
+class Agilent_dx(FileType):
+    filetype: Literal["agilent.dx"]
+
+
+class Agilent_csv(FileType):
+    filetype: Literal["agilent.csv"]
+
+
+class EmpaLC_any(FileType):
+    filetype: Literal["empalc.csv", "empalc.xlsx"]
+
+
+ChromTraceFileTypes = Union[
+    EZChrom_asc,
+    Fusion_json,
+    Fusion_zip,
+    Agilent_ch,
+    Agilent_dx,
+    Agilent_csv,
+]
+
+ChromDataFileTypes = Union[
+    Fusion_json,
+    Fusion_zip,
+    Fusion_csv,
+    EmpaLC_any,
+]
+
+
+class Quadstar_sac(FileType):
+    filetype: Literal["quadstar.sac"]
+
+
+MassTraceFileTypes = Quadstar_sac
+
+
+class LabView_csv(FileType):
+    filetype: Literal["labview.csv"]
+
+
+QFTraceFileTypes = LabView_csv
+
+
+class Phi_spe(FileType):
+    filetype: Literal["phi.spe"]
+
+
+XPSTraceFileTypes = Phi_spe
+
+
+class Panalytical_xrdml(FileType):
+    filetype: Literal["panalytical.xrdml"]
+
+
+class Panalytical_xy(FileType):
+    filetype: Literal["panalytical.xy"]
+
+
+class Panalytical_csv(FileType):
+    filetype: Literal["panalytical.csv"]
+
+
+XRDTraceFileTypes = Union[
+    Panalytical_xrdml,
+    Panalytical_xy,
+    Panalytical_csv,
+]
 
 
 class FileTypeFactory(BaseModel):

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -30,7 +30,7 @@ class Tomato_json(FileType):
     filetype: Literal["tomato.json"]
 
 
-class FileTypeFactory:
+class FileTypeFactory(BaseModel):
     filetype: Union[
         EClab_mpr,
         EClab_mpt,

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -30,11 +30,9 @@ class Tomato_json(FileType):
     filetype: Literal["tomato.json"]
 
 
-FileTypes = Annotated[
-    Union[
-        EClab_mpt,
+class FileTypeFactory:
+    filetype: Union[
         EClab_mpr,
+        EClab_mpt,
         Tomato_json,
-    ],
-    Field(discriminator="filetype"),
-]
+    ] = Field(..., discriminator="filetype")

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -1,20 +1,31 @@
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, validator
 from abc import ABC
 from typing import Optional, Literal, Union
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
+import tzlocal
+import locale
 
 
 class FileType(BaseModel, ABC, extra=Extra.forbid):
     """Template ABC for parser classes."""
 
     filetype: str
-    timezone: Optional[str]
+    timezone: str = "localtime"
     locale: Optional[str]
     encoding: Optional[str]
+
+    @validator("timezone", always=True)
+    @classmethod
+    def timezone_resolve_localtime(cls, v):
+        if v == "localtime":
+            v = tzlocal.get_localzone_name()
+        return v
+
+    @validator("locale", always=True)
+    @classmethod
+    def locale_set_default(cls, v):
+        if v is None:
+            v = ".".join(locale.getlocale())
+        return v
 
 
 class EClab_mpr(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
@@ -91,7 +91,7 @@ class FlowData(Parser):
     """Parser for flow controller/meter data."""
 
     parser: Literal["flowdata"]
-    extractor: FlowDataFileTypes  # = Field(..., discriminator="filetype")
+    extractor: FlowDataFileTypes = Field(..., discriminator="filetype")
 
 
 class ElectroChem(Parser):

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic import BaseModel, Extra, Field
 from abc import ABC
 from typing import Optional, Literal, Mapping, Union
 from .externaldate import ExternalDate
@@ -41,6 +41,7 @@ class Dummy(Parser):
 
     parser: Literal["dummy"]
     parameters: Optional[Parameters]
+    extractor: NoFileType = Field(default_factory=NoFileType)
 
 
 class BasicCSV(Parser):
@@ -83,7 +84,7 @@ class MeasCSV(Parser, extra=Extra.forbid):
 
     parser: Literal["meascsv"]
     parameters: Parameters = Field(default_factory=Parameters)
-    extractor: NoFileType
+    extractor: NoFileType = Field(default_factory=NoFileType)
 
 
 class FlowData(Parser):

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
@@ -51,7 +51,7 @@ class BasicCSV(Parser):
         sep: str = ","
         """Separator of table columns."""
 
-        strip: str = None
+        strip: Optional[str] = None
         """A :class:`str` of characters to strip from headers & data."""
 
         units: Optional[Mapping[str, str]]

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -97,6 +97,7 @@ def test_dataschema_update(inpath, datadir):
         jsdata = json.load(infile)
     ref = jsdata["output"]
     ret = to_dataschema(**jsdata["input"]).update()
+    print(ret)
     assert ref == ret.dict(exclude_none=True)
 
 

--- a/tests/test_dataschema/ts10_chromdata.json
+++ b/tests/test_dataschema/ts10_chromdata.json
@@ -16,7 +16,11 @@
                     "contains": null, 
                     "folders": ["fol"]
                 }, 
-                "filetype": "fusion.json"
+                "extractor": {
+                    "filetype": "fusion.json",
+                    "timezone": "Europe/Berlin",
+                    "locale": "en_GB.UTF-8"
+                }
             }
         ]
     },
@@ -32,11 +36,13 @@
                 "exclude": null
             }, 
             "parameters": null,
-            "filetype": "fusion.json", 
-            "externaldate": null,
-            "timezone": null,
-            "locale": null,
-            "encoding": null
+            "extractor": {
+                "filetype": "fusion.json", 
+                "timezone": "Europe/Berlin",
+                "locale": "en_GB.UTF-8",
+                "encoding": null
+            },
+            "externaldate": null
         }
     ]
 }

--- a/tests/test_dataschema/ts11_basiccsv.json
+++ b/tests/test_dataschema/ts11_basiccsv.json
@@ -11,7 +11,11 @@
         "steps": [
             {
                 "parser": "basiccsv",
-                "input": {"files": ["measurement.csv"]}
+                "input": {"files": ["measurement.csv"]},
+                "extractor": {
+                    "locale": "de_DE.UTF-8",
+                    "timezone": "Europe/Zurich"
+                }
             }
         ]
     },
@@ -25,6 +29,12 @@
                 "contains": null,
                 "exclude": null
             },
+            "extractor": {
+                "filetype": null,
+                "encoding": null,
+                "locale": "de_DE.UTF-8",
+                "timezone": "Europe/Zurich"
+            },
             "tag": null,
             "parameters": {
                 "sep": ",",
@@ -32,11 +42,7 @@
                 "units": null,
                 "strip": null
             },
-            "filetype": null,
-            "externaldate": null,
-            "timezone": null,
-            "locale": null,
-            "encoding": null
+            "externaldate": null
         }
     ]
 }

--- a/tests/test_dataschema/up2_chromtrace.json
+++ b/tests/test_dataschema/up2_chromtrace.json
@@ -9,7 +9,10 @@
             {
                 "parser": "chromtrace",
                 "input": {"files": ["file.dat"]},
-                "parameters": {"filetype": "ezchrom.asc", "calfile": "caldata.json"}
+                "parameters": {
+                    "filetype": "ezchrom.asc", 
+                    "calfile": "caldata.json"
+                }
             }
         ]
     },
@@ -29,8 +32,10 @@
             {
                 "parser": "chromtrace",
                 "input": {"files": ["file.dat"]},
-                "encoding": "UTF-8",
-                "filetype": "ezchrom.asc"
+                "extractor": {
+                    "filetype": "ezchrom.asc",
+                    "encoding": "UTF-8"
+                }
             }
         ]
     }

--- a/tests/test_dataschema/up3_chromdata.json
+++ b/tests/test_dataschema/up3_chromdata.json
@@ -29,8 +29,10 @@
             {
                 "parser": "chromdata",
                 "input": {"files": ["file.dat"]},
-                "encoding": "UTF-8",
-                "filetype": "empalc.csv"
+                "extractor": {
+                    "filetype": "empalc.csv",
+                    "encoding": "UTF-8"
+                }
             }
         ]
     }


### PR DESCRIPTION
This PR changes `DataSchema-5.0` so that `Parsers` are now wrapping around `Extractors`, which are instances of several `FileTypes`.