### PR TITLE
`DataSchema`: Fix `Dummy`.

### DIFF
--- a/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/filetype.py
@@ -34,6 +34,16 @@ class NoFileType(FileType):
     filetype: Optional[None] = None
 
 
+class Tomato_json(FileType):
+    filetype: Literal["tomato.json"]
+
+
+DummyFileTypes = Union[
+    NoFileType,
+    Tomato_json,
+]
+
+
 class Drycal_csv(FileType):
     filetype: Literal["drycal.csv"]
 
@@ -60,10 +70,6 @@ class EClab_mpr(FileType):
 class EClab_mpt(FileType):
     filetype: Literal["eclab.mpt", "marda:biologic-mpt"]
     encoding: str = "windows-1252"
-
-
-class Tomato_json(FileType):
-    filetype: Literal["tomato.json"]
 
 
 ElectroChemFileTypes = Union[

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/step.py
@@ -7,6 +7,7 @@ from .parameters import Parameters, Timestamps, Timestamp
 from .filetype import (
     FileType,
     NoFileType,
+    DummyFileTypes,
     FlowDataFileTypes,
     ElectroChemFileTypes,
     ChromTraceFileTypes,
@@ -41,7 +42,7 @@ class Dummy(Parser):
 
     parser: Literal["dummy"]
     parameters: Optional[Parameters]
-    extractor: NoFileType = Field(default_factory=NoFileType)
+    extractor: DummyFileTypes = Field(default_factory=NoFileType)
 
 
 class BasicCSV(Parser):

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -48,6 +48,7 @@ def test_dataschema_metadata_json(inpath, success, datadir):
         ("ts9_basiccsv.json"),  # 4.2
         ("ts10_chromdata.json"),  # 5.0
         ("ts11_basiccsv.json"),  # 5.0
+        ("ts12_dummy.json"),  # 5.0
     ],
 )
 def test_dataschema_steps_json(inpath, datadir):

--- a/tests/test_dataschema/ts12_dummy.json
+++ b/tests/test_dataschema/ts12_dummy.json
@@ -1,0 +1,45 @@
+{
+    "input": {
+        "metadata": {
+            "version": "5.0",
+            "provenance": {"type": "manual"}
+        },
+        "steps": [
+            {
+                "parser": "dummy",
+                "tag": "test_tag",
+                "input": {"folders": ["fol"], "suffix": ".txt"},
+                "parameters": {"k": "v"},
+                "extractor": {
+                    "filetype": "tomato.json",
+                    "timezone": "Europe/Zurich"
+                },
+                "externaldate": {"using": {"filename": {"len": 10, "format": "%Y_%m_%d"}}}
+            } 
+        ]
+    },
+    "output": [
+        {
+            "parser": "dummy",
+            "input": {
+                "files": ["fol"],
+                "prefix": null,
+                "suffix": ".txt",
+                "contains": null,
+                "exclude": null
+            },
+            "tag": "test_tag",
+            "parameters": {"k": "v"},
+            "extractor": {
+                "encoding": null,
+                "filetype": "tomato.json",
+                "locale": null,
+                "timezone": "Europe/Zurich"
+            },
+            "externaldate": {
+                "using": {"filename": {"len": 10, "format": "%Y_%m_%d"}},
+                "mode": "add"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes the `Dummy` parser by allowing `tomato.json` filetypes. Test added.