### PR TITLE
Implement `DataSchema-5.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 Currently implemented schemas are:
 - `Recipe` validator for **dgpost**, versions `{2.1, 1.0}`
-- `DataSchema` validator for **yadg**, versions `{5.0, 4.2, 4.1, 4.0}`
+- `DataSchema` validator for **yadg**, versions `{5.1, 5.0, 4.2, 4.1, 4.0}`
 - `Payload` validator for **tomato**,  at version `{0.2, 0.1}`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,7 @@ versionfile_source = src/dgbowl_schemas/_version.py
 versionfile_build = dgbowl_schemas/_version.py
 tag_prefix =
 parentdir_prefix = dgbowl_schemas-
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     python_requires=">=3.8",
     install_requires=[
         "pydantic~=2.0",
+        "babel >= 2.15",
         "pyyaml>=5.0",
         "tzlocal",
     ],

--- a/src/dgbowl_schemas/yadg/__init__.py
+++ b/src/dgbowl_schemas/yadg/__init__.py
@@ -2,6 +2,7 @@ import logging
 from . import dataschema
 from pydantic import ValidationError
 from pydantic.v1 import ValidationError as ValidationError_v1
+from .dataschema_5_1 import DataSchema as DataSchema_5_1
 from .dataschema_5_0 import DataSchema as DataSchema_5_0, Metadata as Metadata_5_0
 from .dataschema_4_2 import DataSchema as DataSchema_4_2, Metadata as Metadata_4_2
 from .dataschema_4_1 import DataSchema as DataSchema_4_1, Metadata as Metadata_4_1
@@ -10,6 +11,7 @@ from .dataschema_4_0 import DataSchema as DataSchema_4_0, Metadata as Metadata_4
 logger = logging.getLogger(__name__)
 
 models = {
+    "5.1": (DataSchema_5_1, None),
     "5.0": (DataSchema_5_0, Metadata_5_0),
     "4.2": (DataSchema_4_2, Metadata_4_2),
     "4.1": (DataSchema_4_1, Metadata_4_1),
@@ -23,8 +25,12 @@ def to_dataschema(**kwargs):
     for ver, tup in models.items():
         Model, Metadata = tup
         try:
-            Metadata(**kwargs["metadata"])
-            break
+            if Metadata is None:
+                schema = Model(**kwargs)
+                return schema
+            else:
+                Metadata(**kwargs["metadata"])
+                break
         except (ValidationError, ValidationError_v1) as e:
             errors.append(
                 f"Could not parse 'kwargs['metadata']' using Metadata v{ver}:"

--- a/src/dgbowl_schemas/yadg/dataschema/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema/__init__.py
@@ -2,7 +2,8 @@ from ..dataschema_5_1 import (
     DataSchema,
     StepDefaults,
     FileType,
+    FileTypes,
     ExtractorFactory,
 )
 
-__all__ = ["DataSchema", "StepDefaults", "FileType", "ExtractorFactory"]
+__all__ = ["DataSchema", "StepDefaults", "FileType", "FileTypes", "ExtractorFactory"]

--- a/src/dgbowl_schemas/yadg/dataschema/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema/__init__.py
@@ -1,9 +1,8 @@
-from ..dataschema_5_0 import (
+from ..dataschema_5_1 import (
     DataSchema,
-    Metadata,
     StepDefaults,
     FileType,
     ExtractorFactory,
 )
 
-__all__ = ["DataSchema", "Metadata", "StepDefaults", "FileType", "ExtractorFactory"]
+__all__ = ["DataSchema", "StepDefaults", "FileType", "ExtractorFactory"]

--- a/src/dgbowl_schemas/yadg/dataschema_4_1/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_1/step.py
@@ -141,7 +141,9 @@ class XPSTrace(BaseModel, extra=Extra.forbid):
 class XRDTrace(BaseModel, extra=Extra.forbid):
     class Params(BaseModel, extra=Extra.forbid):
         filetype: Literal[
-            "panalytical.xy", "panalytical.csv", "panalytical.xrdml"
+            "panalytical.xy",
+            "panalytical.csv",
+            "panalytical.xrdml",
         ] = "panalytical.csv"
 
     parser: Literal["xrdtrace"]

--- a/src/dgbowl_schemas/yadg/dataschema_4_2/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_4_2/step.py
@@ -164,7 +164,6 @@ class ElectroChem(BaseModel, extra=Extra.forbid):
     """Parser for electrochemistry files."""
 
     class Params(BaseModel, extra=Extra.forbid):
-
         filetype: Literal["eclab.mpt", "eclab.mpr", "tomato.json"] = "eclab.mpr"
 
         transpose: bool = True

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -54,7 +54,7 @@ class DataSchema(BaseModel, extra="forbid"):
             elif step.parser == "basiccsv":
                 extractor["filetype"] = "basic.csv"
             elif step.parser == "meascsv":
-                extractor["filetype"] = "FHI.csv"
+                extractor["filetype"] = "fhi.csv"
             if step.parameters is not None:
                 extractor["parameters"] = step.parameters.model_dump(exclude_none=True)
             if step.externaldate is not None:

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -44,7 +44,6 @@ class DataSchema(BaseModel, extra="forbid"):
             nstep = {
                 "tag": step.tag,
                 "input": step.input.model_dump(exclude_none=True),
-
             }
             extractor = step.extractor.model_dump(exclude_none=True)
             if step.parser == "dummy":

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Sequence
+import logging
 from .metadata import Metadata
 from .step import Steps
 from .stepdefaults import StepDefaults
@@ -7,6 +8,9 @@ from .filetype import (  # noqa: F401
     ExtractorFactory as ExtractorFactory,
     FileType as FileType,
 )
+from ..dataschema_5_1 import DataSchema as NewDataSchema
+
+logger = logging.getLogger(__name__)
 
 
 class DataSchema(BaseModel, extra="forbid"):
@@ -23,3 +27,38 @@ class DataSchema(BaseModel, extra="forbid"):
 
     steps: Sequence[Steps]
     """Input commands for :mod:`yadg`'s parsers, organised as a sequence of steps."""
+
+    def update(self):
+        logger.info("Updating from DataSchema-5.0 to DataSchema-5.1")
+
+        nsch = {"version": "5.1", "metadata": {}, "step_defaults": {}, "steps": []}
+        for k, v in self.metadata.provenance.model_dump(exclude_none=True).items():
+            if k == "version":
+                continue
+            else:
+                nsch["metadata"][k] = v
+
+        nsch["step_defaults"] = self.step_defaults.model_dump(exclude_none=True)
+
+        for step in self.steps:
+            nstep = {
+                "tag": step.tag,
+                "input": step.input.model_dump(exclude_none=True),
+            }
+            if step.parser == "dummy":
+                if step.extractor.filetype == "tomato.json":
+                    extractor = {"filetype": "tomato.json"}
+                else:
+                    extractor = {"filetype": "example"}
+            elif step.parser == "basiccsv":
+                extractor = {"filetype": "basic.csv"}
+            elif step.parser == "meascsv":
+                extractor = {"filetype": "FHI.csv"}
+            else:
+                extractor = step.extractor.model_dump(exclude_none=True)
+            if step.parameters is not None:
+                extractor["parameters"] = step.parameters.model_dump(exclude_none=True)
+            nstep["extractor"] = extractor
+            nsch["steps"].append(nstep)
+
+        return NewDataSchema(**nsch)

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -44,18 +44,18 @@ class DataSchema(BaseModel, extra="forbid"):
             nstep = {
                 "tag": step.tag,
                 "input": step.input.model_dump(exclude_none=True),
+
             }
+            extractor = step.extractor.model_dump(exclude_none=True)
             if step.parser == "dummy":
                 if step.extractor.filetype == "tomato.json":
-                    extractor = {"filetype": "tomato.json"}
+                    extractor["filetype"] = "tomato.json"
                 else:
-                    extractor = {"filetype": "example"}
+                    extractor["filetype"] = "example"
             elif step.parser == "basiccsv":
-                extractor = {"filetype": "basic.csv"}
+                extractor["filetype"] = "basic.csv"
             elif step.parser == "meascsv":
-                extractor = {"filetype": "FHI.csv"}
-            else:
-                extractor = step.extractor.model_dump(exclude_none=True)
+                extractor["filetype"] = "FHI.csv"
             if step.parameters is not None:
                 extractor["parameters"] = step.parameters.model_dump(exclude_none=True)
             if step.externaldate is not None:

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -38,7 +38,9 @@ class DataSchema(BaseModel, extra="forbid"):
             else:
                 nsch["metadata"][k] = v
 
-        nsch["step_defaults"] = self.step_defaults.model_dump(exclude_none=True)
+        nsch["step_defaults"] = self.step_defaults.model_dump(
+            exclude_none=True, exclude_defaults=True
+        )
 
         for step in self.steps:
             nstep = {

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -54,7 +54,9 @@ class DataSchema(BaseModel, extra="forbid"):
             elif step.parser == "basiccsv":
                 extractor["filetype"] = "basic.csv"
             elif step.parser == "meascsv":
-                extractor["filetype"] = "fhi.csv"
+                extractor["filetype"] = "fhimcpt.csv"
+            if extractor["filetype"] == "labview.csv":
+                extractor["filetype"] = "fhimcpt.vna"
             if step.parameters is not None:
                 extractor["parameters"] = step.parameters.model_dump(exclude_none=True)
             if step.externaldate is not None:

--- a/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/__init__.py
@@ -58,6 +58,8 @@ class DataSchema(BaseModel, extra="forbid"):
                 extractor = step.extractor.model_dump(exclude_none=True)
             if step.parameters is not None:
                 extractor["parameters"] = step.parameters.model_dump(exclude_none=True)
+            if step.externaldate is not None:
+                nstep["externaldate"] = step.externaldate.model_dump(exclude_none=True)
             nstep["extractor"] = extractor
             nsch["steps"].append(nstep)
 

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/__init__.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+from typing import Sequence, Optional, Mapping, Any, Literal
+from .step import Step
+from .stepdefaults import StepDefaults
+from .filetype import (  # noqa: F401
+    ExtractorFactory as ExtractorFactory,
+    FileType as FileType,
+)
+
+
+class DataSchema(BaseModel, extra="forbid"):
+    """
+    A :class:`pydantic.BaseModel` implementing ``DataSchema-5.1`` model
+    introduced in ``yadg-5.1``.
+    """
+
+    version: Literal["5.1"]
+
+    metadata: Optional[Mapping[str, Any]]
+    """Input metadata for :mod:`yadg`."""
+
+    step_defaults: StepDefaults = Field(StepDefaults())
+    """Default values for configuration of each :class:`Step`."""
+
+    steps: Sequence[Step]
+    """Input commands for :mod:`yadg`'s extractors, organised as a :class:`Sequence`
+    of :class:`Steps`."""

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/__init__.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/__init__.py
@@ -5,6 +5,7 @@ from .stepdefaults import StepDefaults
 from .filetype import (  # noqa: F401
     ExtractorFactory as ExtractorFactory,
     FileType as FileType,
+    FileTypes as FileTypes,
 )
 
 

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/externaldate.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/externaldate.py
@@ -1,0 +1,59 @@
+from pydantic import BaseModel
+from typing import Literal, Optional, Union
+
+
+class ExternalDateFile(BaseModel, extra="forbid"):
+    """Read external date information from file."""
+
+    class Content(BaseModel, extra="forbid"):
+        path: str
+        """Path to the external date information file."""
+
+        type: str
+        """Type of the external date information file."""
+
+        match: Optional[str] = None
+        """String to be matched within the file."""
+
+    file: Content
+
+
+class ExternalDateFilename(BaseModel, extra="forbid"):
+    """Read external date information from the file name."""
+
+    class Content(BaseModel, extra="forbid"):
+        format: str
+        """``strptime``-like format string for processing the date."""
+
+        len: int
+        """Number of characters from the start of the filename to parse."""
+
+    filename: Content
+
+
+class ExternalDateISOString(BaseModel, extra="forbid"):
+    """Read a constant external date using an ISO-formatted string."""
+
+    isostring: str
+
+
+class ExternalDateUTSOffset(BaseModel, extra="forbid"):
+    """Read a constant external date using a Unix timestamp offset."""
+
+    utsoffset: float
+
+
+class ExternalDate(BaseModel, extra="forbid"):
+    """Supply timestamping information that are external to the processed file."""
+
+    using: Union[
+        ExternalDateFile,
+        ExternalDateFilename,
+        ExternalDateISOString,
+        ExternalDateUTSOffset,
+    ]
+    """Specification of the external date format."""
+
+    mode: Literal["add", "replace"] = "add"
+    """Whether the external timestamps should be added to or should replace the
+    parsed data."""

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -129,6 +129,10 @@ class EClab_mpt(FileType):
         return v
 
 
+class EZChrom_dat(FileType):
+    filetype: Literal["ezchrom.dat"]
+
+
 class EZChrom_asc(FileType):
     filetype: Literal["ezchrom.asc"]
 

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -237,6 +237,10 @@ class Panalytical_csv(FileType):
     filetype: Literal["panalytical.csv"]
 
 
+class Touchstone_snp(FileType):
+    filetype: Literal["touchstone.snp"]
+
+
 classlist = []
 for name, obj in inspect.getmembers(sys.modules[__name__]):
     if inspect.isclass(obj) and issubclass(obj, FileType) and obj is not FileType:

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -133,7 +133,7 @@ class EClab_mpr(FileType):
 
 class EClab_mpt(FileType):
     filetype: Literal["eclab.mpt", "biologic-mpt"]
-    encoding: str = "windows-1252"
+    encoding: Optional[str] = "windows-1252"
 
     @field_validator("filetype")
     @classmethod
@@ -147,6 +147,11 @@ class EClab_mpt(FileType):
             )
             v = ok
         return v
+
+    @field_validator("encoding")
+    @classmethod
+    def set_encoding(cls, encoding):
+        return encoding or "windows-1252"
 
 
 class EmpaLC_csv(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -168,8 +168,12 @@ class EZChrom_dat(FileType):
 
 class EZChrom_asc(FileType):
     filetype: Literal["ezchrom.asc"]
-    encoding: str = "windows-1252"
+    encoding: Optional[str] = "windows-1252"
 
+    @field_validator("encoding")
+    @classmethod
+    def set_encoding(cls, encoding):
+        return encoding or "windows-1252"
 
 class FHI_csv(FileType):
     class Parameters(BaseModel, extra="forbid"):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -60,7 +60,7 @@ class Agilent_ch(FileType):
         ok = "agilent.ch"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok
@@ -77,7 +77,7 @@ class Agilent_dx(FileType):
         ok = "agilent.dx"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok
@@ -129,7 +129,7 @@ class EClab_mpr(FileType):
         ok = "eclab.mpr"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok
@@ -147,7 +147,7 @@ class EClab_mpt(FileType):
         ok = "eclab.mpt"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok
@@ -229,7 +229,7 @@ class Panalytical_xrdml(FileType):
         ok = "panalytical.xrdml"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok
@@ -246,7 +246,7 @@ class Phi_spe(FileType):
         ok = "phi.spe"
         if v == dep:
             logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
+                f"Using {dep!r} as a filetype alias for {ok!r} "
                 "is deprecated and will stop working in DataSchema-6.0"
             )
             v = ok

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -5,9 +5,12 @@ from abc import ABC
 from typing import Optional, Literal, Union, Mapping, Any
 import tzlocal
 import locale
+import logging
 
 from .stepdefaults import StepDefaults
 from .parameters import Timestamps, Timestamp
+
+logger = logging.getLogger(__name__)
 
 
 class FileType(BaseModel, ABC, extra="forbid"):
@@ -92,12 +95,34 @@ class Drycal_txt(FileType):
 
 
 class EClab_mpr(FileType):
-    filetype: Literal["eclab.mpr"]
+    filetype: Literal["eclab.mpr", "biologic-mpr"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="biologic-mpr", ok="eclab.mpr"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class EClab_mpt(FileType):
-    filetype: Literal["eclab.mpt"]
+    filetype: Literal["eclab.mpt", "biologic-mpt"]
     encoding: str = "windows-1252"
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="biologic-mpt", ok="eclab.mpt"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class EZChrom_asc(FileType):
@@ -117,11 +142,33 @@ class Fusion_csv(FileType):
 
 
 class Agilent_ch(FileType):
-    filetype: Literal["agilent.ch"]
+    filetype: Literal["agilent.ch", "agilent-ch"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="agilent-ch", ok="agilent.ch"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class Agilent_dx(FileType):
-    filetype: Literal["agilent.dx"]
+    filetype: Literal["agilent.dx", "agilent-dx"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="agilent-dx", ok="agilent.dx"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class Agilent_csv(FileType):
@@ -141,11 +188,33 @@ class Quadstar_sac(FileType):
 
 
 class Phi_spe(FileType):
-    filetype: Literal["phi.spe"]
+    filetype: Literal["phi.spe", "phi-spe"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="phi-spe", ok="phi.spe"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class Panalytical_xrdml(FileType):
-    filetype: Literal["panalytical.xrdml"]
+    filetype: Literal["panalytical.xrdml", "panalytical-xrdml"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v, dep="panalytical-xrdml", ok="panalytical.xrdml"):
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
 class Panalytical_xy(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -45,6 +45,44 @@ class Example(FileType):
     filetype: Literal["example"]
 
 
+class Agilent_ch(FileType):
+    filetype: Literal["agilent.ch", "agilent-ch"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v):
+        dep = "agilent-ch"
+        ok = "agilent.ch"
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
+
+
+class Agilent_dx(FileType):
+    filetype: Literal["agilent.dx", "agilent-dx"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v):
+        dep = "agilent-dx"
+        ok = "agilent.dx"
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
+
+
+class Agilent_csv(FileType):
+    filetype: Literal["agilent.csv"]
+
+
 class Basic_csv(FileType):
     class Parameters(BaseModel, extra="forbid"):
         sep: str = ","
@@ -62,24 +100,6 @@ class Basic_csv(FileType):
 
     parameters: Parameters = Field(default_factory=Parameters)
     filetype: Literal["basic.csv"]
-
-
-class FHI_csv(FileType):
-    class Parameters(BaseModel, extra="forbid"):
-        timestamp: Timestamps = Field(
-            Timestamp(timestamp={"index": 0, "format": "%Y-%m-%d-%H-%M-%S"})
-        )
-
-    parameters: Parameters = Field(default_factory=Parameters)
-    filetype: Literal["fhimcpt.csv"]
-
-
-class FHI_vna(FileType):
-    filetype: Literal["fhimcpt.vna"]
-
-
-class Tomato_json(FileType):
-    filetype: Literal["tomato.json"]
 
 
 class Drycal_csv(FileType):
@@ -129,6 +149,14 @@ class EClab_mpt(FileType):
         return v
 
 
+class EmpaLC_csv(FileType):
+    filetype: Literal["empalc.csv"]
+
+
+class EmpaLC_xlsx(FileType):
+    filetype: Literal["empalc.xlsx"]
+
+
 class EZChrom_dat(FileType):
     filetype: Literal["ezchrom.dat"]
 
@@ -136,6 +164,20 @@ class EZChrom_dat(FileType):
 class EZChrom_asc(FileType):
     filetype: Literal["ezchrom.asc"]
     encoding: str = "windows-1252"
+
+
+class FHI_csv(FileType):
+    class Parameters(BaseModel, extra="forbid"):
+        timestamp: Timestamps = Field(
+            Timestamp(timestamp={"index": 0, "format": "%Y-%m-%d-%H-%M-%S"})
+        )
+
+    parameters: Parameters = Field(default_factory=Parameters)
+    filetype: Literal["fhimcpt.csv"]
+
+
+class FHI_vna(FileType):
+    filetype: Literal["fhimcpt.vna"]
 
 
 class Fusion_json(FileType):
@@ -150,71 +192,16 @@ class Fusion_csv(FileType):
     filetype: Literal["fusion.csv"]
 
 
-class Agilent_ch(FileType):
-    filetype: Literal["agilent.ch", "agilent-ch"]
-
-    @field_validator("filetype")
-    @classmethod
-    def warn_deprecated(cls, v):
-        dep = "agilent-ch"
-        ok = "agilent.ch"
-        if v == dep:
-            logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
-                "is deprecated and will stop working in DataSchema-6.0"
-            )
-            v = ok
-        return v
+class Panalytical_xy(FileType):
+    filetype: Literal["panalytical.xy"]
 
 
-class Agilent_dx(FileType):
-    filetype: Literal["agilent.dx", "agilent-dx"]
-
-    @field_validator("filetype")
-    @classmethod
-    def warn_deprecated(cls, v):
-        dep = "agilent-dx"
-        ok = "agilent.dx"
-        if v == dep:
-            logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
-                "is deprecated and will stop working in DataSchema-6.0"
-            )
-            v = ok
-        return v
+class Panalytical_csv(FileType):
+    filetype: Literal["panalytical.csv"]
 
 
-class Agilent_csv(FileType):
-    filetype: Literal["agilent.csv"]
-
-
-class EmpaLC_csv(FileType):
-    filetype: Literal["empalc.csv"]
-
-
-class EmpaLC_xlsx(FileType):
-    filetype: Literal["empalc.xlsx"]
-
-
-class Quadstar_sac(FileType):
-    filetype: Literal["quadstar.sac"]
-
-
-class Phi_spe(FileType):
-    filetype: Literal["phi.spe", "phi-spe"]
-
-    @field_validator("filetype")
-    @classmethod
-    def warn_deprecated(cls, v):
-        dep = "phi-spe"
-        ok = "phi.spe"
-        if v == dep:
-            logger.warning(
-                f"Using {dep!r} as a filetype alias for {ok!r}"
-                "is deprecated and will stop working in DataSchema-6.0"
-            )
-            v = ok
-        return v
+class PicoLog_tc08(FileType):
+    filetype: Literal["picolog.tc08"]
 
 
 class Panalytical_xrdml(FileType):
@@ -234,12 +221,29 @@ class Panalytical_xrdml(FileType):
         return v
 
 
-class Panalytical_xy(FileType):
-    filetype: Literal["panalytical.xy"]
+class Phi_spe(FileType):
+    filetype: Literal["phi.spe", "phi-spe"]
+
+    @field_validator("filetype")
+    @classmethod
+    def warn_deprecated(cls, v):
+        dep = "phi-spe"
+        ok = "phi.spe"
+        if v == dep:
+            logger.warning(
+                f"Using {dep!r} as a filetype alias for {ok!r}"
+                "is deprecated and will stop working in DataSchema-6.0"
+            )
+            v = ok
+        return v
 
 
-class Panalytical_csv(FileType):
-    filetype: Literal["panalytical.csv"]
+class Quadstar_sac(FileType):
+    filetype: Literal["quadstar.sac"]
+
+
+class Tomato_json(FileType):
+    filetype: Literal["tomato.json"]
 
 
 class Touchstone_snp(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -175,6 +175,7 @@ class EZChrom_asc(FileType):
     def set_encoding(cls, encoding):
         return encoding or "windows-1252"
 
+
 class FHI_csv(FileType):
     class Parameters(BaseModel, extra="forbid"):
         timestamp: Timestamps = Field(

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -269,7 +269,7 @@ classlist = []
 for name, obj in inspect.getmembers(sys.modules[__name__]):
     if inspect.isclass(obj) and issubclass(obj, FileType) and obj is not FileType:
         classlist.append(obj)
-FileTypes = TypeVar('FileTypes', *classlist)
+FileTypes = TypeVar("FileTypes", *classlist)
 
 
 class ExtractorFactory(BaseModel):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -7,7 +7,7 @@ import tzlocal
 import locale
 
 from .stepdefaults import StepDefaults
-from .parameters import Parameters, Timestamps, Timestamp
+from .parameters import Timestamps, Timestamp
 
 
 class FileType(BaseModel, ABC, extra="forbid"):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -99,7 +99,9 @@ class EClab_mpr(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="biologic-mpr", ok="eclab.mpr"):
+    def warn_deprecated(cls, v):
+        dep = "biologic-mpr"
+        ok = "eclab.mpr"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"
@@ -115,7 +117,9 @@ class EClab_mpt(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="biologic-mpt", ok="eclab.mpt"):
+    def warn_deprecated(cls, v):
+        dep = "biologic-mpt"
+        ok = "eclab.mpt"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"
@@ -146,7 +150,9 @@ class Agilent_ch(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="agilent-ch", ok="agilent.ch"):
+    def warn_deprecated(cls, v):
+        dep = "agilent-ch"
+        ok = "agilent.ch"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"
@@ -161,7 +167,9 @@ class Agilent_dx(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="agilent-dx", ok="agilent.dx"):
+    def warn_deprecated(cls, v):
+        dep = "agilent-dx"
+        ok = "agilent.dx"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"
@@ -192,7 +200,9 @@ class Phi_spe(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="phi-spe", ok="phi.spe"):
+    def warn_deprecated(cls, v):
+        dep = "phi-spe"
+        ok = "phi.spe"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"
@@ -207,7 +217,9 @@ class Panalytical_xrdml(FileType):
 
     @field_validator("filetype")
     @classmethod
-    def warn_deprecated(cls, v, dep="panalytical-xrdml", ok="panalytical.xrdml"):
+    def warn_deprecated(cls, v):
+        dep = "panalytical-xrdml"
+        ok = "panalytical.xrdml"
         if v == dep:
             logger.warning(
                 f"Using {dep!r} as a filetype alias for {ok!r}"

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -135,6 +135,7 @@ class EZChrom_dat(FileType):
 
 class EZChrom_asc(FileType):
     filetype: Literal["ezchrom.asc"]
+    encoding: str = "windows-1252"
 
 
 class Fusion_json(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -5,6 +5,7 @@ from abc import ABC
 from typing import Optional, Literal, Union, Mapping, Any
 import tzlocal
 import locale
+from babel import Locale, UnknownLocaleError
 import logging
 
 from .stepdefaults import StepDefaults
@@ -32,8 +33,12 @@ class FileType(BaseModel, ABC, extra="forbid"):
     @field_validator("locale")
     @classmethod
     def locale_set_default(cls, v):
-        if v == "getlocale":
-            v = ".".join(locale.getlocale())
+        if v is None:
+            v = locale.getlocale(locale.LC_NUMERIC)[0]
+        try:
+            v = str(Locale.parse(v))
+        except (TypeError, UnknownLocaleError):
+            v = "en_GB"
         return v
 
 
@@ -288,7 +293,9 @@ class ExtractorFactory(BaseModel):
     @field_validator("extractor")
     @classmethod
     def extractor_set_defaults(cls, v):
+        print(f"{v=}")
         defaults = StepDefaults()
+        print(f"{defaults=}")
         if v.timezone is None:
             v.timezone = defaults.timezone
         if v.locale is None:

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -293,9 +293,7 @@ class ExtractorFactory(BaseModel):
     @field_validator("extractor")
     @classmethod
     def extractor_set_defaults(cls, v):
-        print(f"{v=}")
         defaults = StepDefaults()
-        print(f"{defaults=}")
         if v.timezone is None:
             v.timezone = defaults.timezone
         if v.locale is None:

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -160,7 +160,7 @@ classlist = []
 for name, obj in inspect.getmembers(sys.modules[__name__]):
     if inspect.isclass(obj) and issubclass(obj, FileType) and obj is not FileType:
         classlist.append(obj)
-FileTypes = Union[tuple(classlist)]
+FileTypes = tuple(classlist)
 
 
 class ExtractorFactory(BaseModel):
@@ -179,7 +179,7 @@ class ExtractorFactory(BaseModel):
         ftype = ExtractorFactory(extractor={"filetype": k}).extractor
     """
 
-    extractor: FileTypes = Field(..., discriminator="filetype")
+    extractor: Union[FileTypes] = Field(..., discriminator="filetype")
 
     @field_validator("extractor")
     @classmethod

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -1,0 +1,193 @@
+import sys
+import inspect
+from pydantic import BaseModel, Field, field_validator
+from abc import ABC
+from typing import Optional, Literal, Union, Mapping
+import tzlocal
+import locale
+
+from .stepdefaults import StepDefaults
+from .parameters import Parameters, Timestamps, Timestamp
+
+
+class FileType(BaseModel, ABC, extra="forbid"):
+    """Template abstract base class for parser classes."""
+
+    filetype: Optional[str] = None
+    timezone: Optional[str] = None
+    locale: Optional[str] = None
+    encoding: Optional[str] = None
+
+    @field_validator("timezone")
+    @classmethod
+    def timezone_resolve_localtime(cls, v):
+        if v == "localtime":
+            v = tzlocal.get_localzone_name()
+        return v
+
+    @field_validator("locale")
+    @classmethod
+    def locale_set_default(cls, v):
+        if v == "getlocale":
+            v = ".".join(locale.getlocale())
+        return v
+
+
+class Example(FileType):
+    class Parameters(BaseModel, extra="allow"):
+        pass
+
+    parameters: Parameters = Field(default_factory=Parameters)
+    filetype: Literal["example"]
+
+
+class Basic_csv(FileType):
+    class Parameters(BaseModel, extra="forbid"):
+        sep: str = ","
+        """Separator of table columns."""
+
+        strip: Optional[str] = None
+        """A :class:`str` of characters to strip from headers & data."""
+
+        units: Optional[Mapping[str, str]] = None
+        """A :class:`dict` containing ``column: unit`` keypairs."""
+
+        timestamp: Optional[Timestamps] = None
+        """Timestamp specification allowing calculation of Unix timestamp for
+        each table row."""
+
+    parameters: Parameters = Field(default_factory=Parameters)
+    filetype: Literal["basic.csv"]
+
+
+class FHI_csv(FileType):
+    class Parameters(BaseModel, extra="forbid"):
+        timestamp: Timestamps = Field(
+            Timestamp(timestamp={"index": 0, "format": "%Y-%m-%d-%H-%M-%S"})
+        )
+
+    parameters: Parameters = Field(default_factory=Parameters)
+    filetype: Literal["fhi.csv"]
+
+
+class Tomato_json(FileType):
+    filetype: Literal["tomato.json"]
+
+
+class Drycal_csv(FileType):
+    filetype: Literal["drycal.csv"]
+
+
+class Drycal_rtf(FileType):
+    filetype: Literal["drycal.rtf"]
+
+
+class Drycal_txt(FileType):
+    filetype: Literal["drycal.txt"]
+
+
+class EClab_mpr(FileType):
+    filetype: Literal["eclab.mpr"]
+
+
+class EClab_mpt(FileType):
+    filetype: Literal["eclab.mpt"]
+    encoding: str = "windows-1252"
+
+
+class EZChrom_asc(FileType):
+    filetype: Literal["ezchrom.asc"]
+
+
+class Fusion_json(FileType):
+    filetype: Literal["fusion.json"]
+
+
+class Fusion_zip(FileType):
+    filetype: Literal["fusion.zip"]
+
+
+class Fusion_csv(FileType):
+    filetype: Literal["fusion.csv"]
+
+
+class Agilent_ch(FileType):
+    filetype: Literal["agilent.ch"]
+
+
+class Agilent_dx(FileType):
+    filetype: Literal["agilent.dx"]
+
+
+class Agilent_csv(FileType):
+    filetype: Literal["agilent.csv"]
+
+
+class EmpaLC_csv(FileType):
+    filetype: Literal["empalc.csv"]
+
+
+class EmpaLC_xlsx(FileType):
+    filetype: Literal["empalc.xlsx"]
+
+
+class Quadstar_sac(FileType):
+    filetype: Literal["quadstar.sac"]
+
+
+class LabView_csv(FileType):
+    filetype: Literal["labview.csv"]
+
+
+class Phi_spe(FileType):
+    filetype: Literal["phi.spe"]
+
+
+class Panalytical_xrdml(FileType):
+    filetype: Literal["panalytical.xrdml"]
+
+
+class Panalytical_xy(FileType):
+    filetype: Literal["panalytical.xy"]
+
+
+class Panalytical_csv(FileType):
+    filetype: Literal["panalytical.csv"]
+
+
+classlist = []
+for name, obj in inspect.getmembers(sys.modules[__name__]):
+    if inspect.isclass(obj) and issubclass(obj, FileType) and obj is not FileType:
+        classlist.append(obj)
+FileTypes = Union[tuple(classlist)]
+
+
+class ExtractorFactory(BaseModel):
+    """
+    Extractor factory class.
+
+    Given an ``extractor=dict(filetype=k, ...)`` argument, attempts to determine the
+    correct :class:`FileType`, parses any additionally supplied parameters for that
+    :class:`FileType`, and back-fills defaults such as ``timezone``, ``locale``, and
+    ``encoding``.
+
+    The following is the current usage pattern in :mod:`yadg`:
+
+    .. code-block::
+
+        ftype = ExtractorFactory(extractor={"filetype": k}).extractor
+    """
+
+    extractor: FileTypes = Field(..., discriminator="filetype")
+
+    @field_validator("extractor")
+    @classmethod
+    def extractor_set_defaults(cls, v):
+        defaults = StepDefaults()
+        if v.timezone is None:
+            v.timezone = defaults.timezone
+        if v.locale is None:
+            v.locale = defaults.locale
+        if v.encoding is None:
+            v.encoding = defaults.encoding
+        return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -2,7 +2,7 @@ import sys
 import inspect
 from pydantic import BaseModel, Field, field_validator
 from abc import ABC
-from typing import Optional, Literal, Union, Mapping, Any
+from typing import Optional, Literal, Mapping, Any, TypeVar
 import tzlocal
 import locale
 from babel import Locale, UnknownLocaleError
@@ -269,7 +269,7 @@ classlist = []
 for name, obj in inspect.getmembers(sys.modules[__name__]):
     if inspect.isclass(obj) and issubclass(obj, FileType) and obj is not FileType:
         classlist.append(obj)
-FileTypes = tuple(classlist)
+FileTypes = TypeVar('FileTypes', *classlist)
 
 
 class ExtractorFactory(BaseModel):
@@ -288,7 +288,7 @@ class ExtractorFactory(BaseModel):
         ftype = ExtractorFactory(extractor={"filetype": k}).extractor
     """
 
-    extractor: Union[FileTypes] = Field(..., discriminator="filetype")
+    extractor: FileTypes = Field(..., discriminator="filetype")
 
     @field_validator("extractor")
     @classmethod

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -68,7 +68,11 @@ class FHI_csv(FileType):
         )
 
     parameters: Parameters = Field(default_factory=Parameters)
-    filetype: Literal["fhi.csv"]
+    filetype: Literal["fhimcpt.csv"]
+
+
+class FHI_vna(FileType):
+    filetype: Literal["fhimcpt.vna"]
 
 
 class Tomato_json(FileType):
@@ -134,10 +138,6 @@ class EmpaLC_xlsx(FileType):
 
 class Quadstar_sac(FileType):
     filetype: Literal["quadstar.sac"]
-
-
-class LabView_csv(FileType):
-    filetype: Literal["labview.csv"]
 
 
 class Phi_spe(FileType):

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/filetype.py
@@ -2,7 +2,7 @@ import sys
 import inspect
 from pydantic import BaseModel, Field, field_validator
 from abc import ABC
-from typing import Optional, Literal, Union, Mapping
+from typing import Optional, Literal, Union, Mapping, Any
 import tzlocal
 import locale
 
@@ -17,6 +17,7 @@ class FileType(BaseModel, ABC, extra="forbid"):
     timezone: Optional[str] = None
     locale: Optional[str] = None
     encoding: Optional[str] = None
+    parameters: Optional[Any] = None
 
     @field_validator("timezone")
     @classmethod

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/input.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/input.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Sequence, List
+import os
+
+
+class Input(BaseModel, extra="forbid", populate_by_name=True):
+    """Specification of input files/folders to be processed by the :class:`Step`."""
+
+    files: Sequence[str] = Field(alias="folders")
+    """Files, or folders to be searched for matching files."""
+
+    prefix: Optional[str] = None
+    """Prefix of the filenames to be matched."""
+
+    suffix: Optional[str] = None
+    """Suffix of the filenames to be matched."""
+
+    contains: Optional[str] = None
+    """A string the matched filenames must contain."""
+
+    exclude: Optional[str] = None
+    """A string the matched filenames must not contain."""
+
+    def paths(self) -> List[str]:
+        """Returns a list of files to be processed by the :class:`Step`."""
+        ret = []
+        for item in sorted(self.files):
+            if os.path.isdir(item):
+                paths = [os.path.join(item, fn) for fn in sorted(os.listdir(item))]
+            else:
+                paths = [item]
+            for path in paths:
+                tail = os.path.basename(path)
+                inc = True
+                if self.prefix is not None and not tail.startswith(self.prefix):
+                    inc = False
+                if self.suffix is not None and not tail.endswith(self.suffix):
+                    inc = False
+                if self.contains is not None and self.contains not in tail:
+                    inc = False
+                if self.exclude is not None and self.exclude in tail:
+                    inc = False
+                if inc:
+                    ret.append(path)
+        return ret

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/parameters.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/parameters.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Union
+
+from .timestamp import Timestamp, TimeDate, UTS
+
+
+class Parameters(BaseModel, extra="forbid"):
+    """Empty parameters specification with no extras allowed."""
+
+    pass
+
+
+Timestamps = Union[Timestamp, TimeDate, UTS]

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/step.py
@@ -1,12 +1,12 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, Union
 from .externaldate import ExternalDate
 from .input import Input
 from .filetype import FileTypes
 
 
 class Step(BaseModel, extra="forbid"):
-    extractor: FileTypes
+    extractor: Union[FileTypes]
     input: Input
     tag: Optional[str] = None
     externaldate: Optional[ExternalDate] = None

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/step.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/step.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Optional
+from .externaldate import ExternalDate
+from .input import Input
+from .filetype import FileTypes
+
+
+class Step(BaseModel, extra="forbid"):
+    extractor: FileTypes
+    input: Input
+    tag: Optional[str] = None
+    externaldate: Optional[ExternalDate] = None

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, Tuple, Union
+import locale
+import tzlocal
+
+
+class StepDefaults(BaseModel, extra="forbid"):
+    """Configuration of defaults applicable for all steps."""
+
+    timezone: str = Field("localtime", validate_default=True)
+    """Global timezone specification.
+
+    .. note::
+
+        This should be set to the timezone where the measurements have been
+        performed, as opposed to the timezone where :mod:`yadg` is being executed.
+        Otherwise timezone offsets may not be accounted for correctly.
+
+    """
+
+    locale: Union[Tuple[str, str], str, None] = Field(None, validate_default=True)
+    """Global locale specification. Will default to current locale."""
+
+    encoding: Optional[str] = None
+    """Global filetype encoding. Will default to ``None``."""
+
+    @field_validator("timezone")
+    @classmethod
+    def timezone_resolve_localtime(cls, v):
+        if v == "localtime":
+            v = tzlocal.get_localzone_name()
+        return v
+
+    @field_validator("locale")
+    @classmethod
+    def locale_set_default(cls, v):
+        if v is None:
+            v = ".".join(locale.getlocale())
+        return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -19,7 +19,7 @@ class StepDefaults(BaseModel, extra="forbid"):
 
     """
 
-    locale: Union[Tuple[str, str], str, None] = Field(None, validate_default=True)
+    locale: Optional[str] = Field(None, validate_default=True)
     """Global locale specification. Will default to current locale."""
 
     encoding: Optional[str] = "utf-8"
@@ -36,9 +36,9 @@ class StepDefaults(BaseModel, extra="forbid"):
     @classmethod
     def locale_set_default(cls, v):
         if v is None:
-            v = locale.getlocale(locale.LC_NUMERIC)
+            v = locale.getlocale(locale.LC_NUMERIC)[0]
         try:
-            v = Locale.parse(v)
+            v = str(Locale.parse(v))
         except (TypeError, UnknownLocaleError):
             v = "en_GB"
         return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Tuple, Union
 import locale
+from babel import Locale, UnknownLocaleError
 import tzlocal
 
 
@@ -35,5 +36,9 @@ class StepDefaults(BaseModel, extra="forbid"):
     @classmethod
     def locale_set_default(cls, v):
         if v is None:
-            v = ".".join(locale.getlocale())
+            v = locale.getlocale(locale.LC_NUMERIC)
+        try:
+            v = Locale.parse(v)
+        except (TypeError, UnknownLocaleError):
+            v = "en_GB"
         return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -21,8 +21,8 @@ class StepDefaults(BaseModel, extra="forbid"):
     locale: Union[Tuple[str, str], str, None] = Field(None, validate_default=True)
     """Global locale specification. Will default to current locale."""
 
-    encoding: Optional[str] = None
-    """Global filetype encoding. Will default to ``None``."""
+    encoding: Optional[str] = "utf-8"
+    """Global filetype encoding. Will default to ``utf-8``."""
 
     @field_validator("timezone")
     @classmethod

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, field_validator
-from typing import Optional, Tuple, Union
+from typing import Optional
 import locale
 from babel import Locale, UnknownLocaleError
 import tzlocal

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/timestamp.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/timestamp.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class TimestampSpec(BaseModel, extra="forbid"):
+    """Specification of the column index and string format of the timestamp."""
+
+    index: Optional[int] = None
+    format: Optional[str] = None
+
+
+class Timestamp(BaseModel, extra="forbid"):
+    """Timestamp from a column containing a single timestamp string."""
+
+    timestamp: TimestampSpec
+
+
+class UTS(BaseModel, extra="forbid"):
+    """Timestamp from a column containing a Unix timestamp."""
+
+    uts: TimestampSpec
+
+
+class TimeDate(BaseModel, extra="forbid"):
+    """Timestamp from a separate date and/or time column."""
+
+    date: Optional[TimestampSpec] = None
+    time: Optional[TimestampSpec] = None

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -135,6 +135,7 @@ def test_dataschema_update_chain(inpath, datadir):
             {
                 "filetype": "eclab.mpr",
                 "locale": "en_GB.UTF-8",
+                "encoding": "utf-8",
             },
         ),
         (  # ts1 - mpt file, mixture of inputs and defaults from extractor

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -111,6 +111,7 @@ def test_dataschema_update(inpath, datadir):
     [
         ("chain_vna_4.0.json"),  # 4.0
         ("chain_gc_4.0.json"),  # 4.0
+        ("chain_externaldate_4.0.json"),  # 4.0
         ("chain_basiccsv_4.1.json"),  # 4.1
     ],
 )

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -135,7 +135,7 @@ def test_dataschema_update_chain(inpath, datadir):
             },
             {
                 "filetype": "eclab.mpr",
-                "locale": "en_GB.UTF-8",
+                "locale": "en_GB",
                 "encoding": "utf-8",
             },
         ),
@@ -147,7 +147,7 @@ def test_dataschema_update_chain(inpath, datadir):
             },
             {
                 "filetype": "eclab.mpt",
-                "locale": "de_DE.UTF-8",
+                "locale": "de_DE",
                 "timezone": "Europe/Zurich",
                 "encoding": "windows-1252",
             },
@@ -155,8 +155,9 @@ def test_dataschema_update_chain(inpath, datadir):
     ],
 )
 def test_extractor_factory(input, output):
-    locale.setlocale(locale.LC_CTYPE, "en_GB.UTF-8")
+    locale.setlocale(locale.LC_NUMERIC, "en_GB.UTF-8")
     ret = ExtractorFactory(extractor=input).extractor
+    print(f"{ret=}")
     assert ret.filetype == output.get("filetype")
     assert ret.locale == output.get("locale")
     assert ret.encoding == output.get("encoding")

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -49,6 +49,9 @@ def test_dataschema_metadata_json(inpath, success, datadir):
         ("ts10_chromdata.json"),  # 5.0
         ("ts11_basiccsv.json"),  # 5.0
         ("ts12_dummy.json"),  # 5.0
+        ("ts13_fusion_json.json"),  # 5.1
+        ("ts14_basic_csv.json"),  # 5.1
+        ("ts15_example.json"),  # 5.1
     ],
 )
 def test_dataschema_steps_json(inpath, datadir):

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -4,6 +4,7 @@ import json
 from dgbowl_schemas.yadg import to_dataschema
 from dgbowl_schemas.yadg.dataschema import ExtractorFactory
 import locale
+from pydantic import BaseModel
 
 
 @pytest.mark.parametrize(
@@ -59,11 +60,11 @@ def test_dataschema_steps_json(inpath, datadir):
     with open(inpath, "r") as infile:
         jsdata = json.load(infile)
     ref = jsdata["output"]
-    ret = to_dataschema(**jsdata["input"])
+    ret: BaseModel = to_dataschema(**jsdata["input"])
     if hasattr(ret, "model_dump"):
-        ret = ret.model_dump(exclude_none=True)
+        ret = ret.model_dump()
     else:
-        ret = ret.dict(exclude_none=True)
+        ret = ret.dict()
     assert ret["steps"] == ref
 
 

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -60,7 +60,11 @@ def test_dataschema_steps_json(inpath, datadir):
         jsdata = json.load(infile)
     ref = jsdata["output"]
     ret = to_dataschema(**jsdata["input"])
-    assert ret.dict()["steps"] == ref
+    if hasattr(ret, "model_dump"):
+        ret = ret.model_dump(exclude_none=True)
+    else:
+        ret = ret.dict(exclude_none=True)
+    assert ret["steps"] == ref
 
 
 @pytest.mark.parametrize(
@@ -102,8 +106,11 @@ def test_dataschema_update(inpath, datadir):
         jsdata = json.load(infile)
     ref = jsdata["output"]
     ret = to_dataschema(**jsdata["input"]).update()
-    print(ret)
-    assert ref == ret.dict(exclude_none=True)
+    if hasattr(ret, "model_dump"):
+        ret = ret.model_dump(exclude_none=True)
+    else:
+        ret = ret.dict(exclude_none=True)
+    assert ret == ref
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dataschema.py
+++ b/tests/test_dataschema.py
@@ -122,7 +122,7 @@ def test_dataschema_update_chain(inpath, datadir):
     ret = to_dataschema(**jsdata)
     while hasattr(ret, "update"):
         ret = ret.update()
-    assert ret.metadata.version == "5.0"
+    assert ret.version == "5.1"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dataschema/chain_externaldate_4.0.json
+++ b/tests/test_dataschema/chain_externaldate_4.0.json
@@ -1,0 +1,22 @@
+{
+    "metadata": {
+        "provenance": "manual",
+        "schema_version": "4.0",
+        "timezone": "UTC"
+    },
+    "steps": [
+        {
+            "parser": "basiccsv",
+            "import": {
+                "files": ["case_time_custom.csv"],
+                "encoding": "utf-8"
+            },
+            "parameters": {
+                "sep": ",",
+                "sigma": {"col": {"atol": 1e-4}}
+            },
+            "externaldate": {"from": {"isostring": "2021-01-01"}}
+        }
+
+    ]
+}

--- a/tests/test_dataschema/err5_typo.json
+++ b/tests/test_dataschema/err5_typo.json
@@ -16,5 +16,5 @@
             }
         ]
     },
-    "exception": "type=literal_error, input_value='typo'"
+    "exception": "Input tag 'typo' found using 'parser'"
 }

--- a/tests/test_dataschema/err5_typo.json
+++ b/tests/test_dataschema/err5_typo.json
@@ -16,5 +16,5 @@
             }
         ]
     },
-    "exception": "Input tag 'typo' found using 'parser' does not match any of the expected tags:"
+    "exception": "type=literal_error, input_value='typo'"
 }

--- a/tests/test_dataschema/err5_typo.json
+++ b/tests/test_dataschema/err5_typo.json
@@ -16,5 +16,5 @@
             }
         ]
     },
-    "exception": "Input tag 'typo' found using 'parser'"
+    "exception": "input_value='typo'"
 }

--- a/tests/test_dataschema/ts13_fusion_json.json
+++ b/tests/test_dataschema/ts13_fusion_json.json
@@ -1,0 +1,45 @@
+{
+    "input": {
+        "version": "5.1",
+        "metadata": {
+            "provenance": {"type": "datagram_from_input"}
+        },
+        "step_defaults": {
+            "timezone": "UTC"
+        },
+        "steps": [
+            {
+                "input": {
+                    "prefix": null,
+                    "suffix": "txt",
+                    "contains": null,
+                    "folders": ["fol"]
+                },
+                "extractor": {
+                    "filetype": "fusion.json",
+                    "timezone": "Europe/Berlin",
+                    "locale": "en_GB.UTF-8"
+                }
+            }
+        ]
+    },
+    "output": [
+        {
+            "tag": null,
+            "input": {
+                "prefix": null,
+                "suffix": "txt",
+                "contains": null,
+                "files": ["fol"],
+                "exclude": null
+            },
+            "extractor": {
+                "filetype": "fusion.json",
+                "timezone": "Europe/Berlin",
+                "locale": "en_GB.UTF-8",
+                "encoding": null
+            },
+            "externaldate": null
+        }
+    ]
+}

--- a/tests/test_dataschema/ts13_fusion_json.json
+++ b/tests/test_dataschema/ts13_fusion_json.json
@@ -36,7 +36,7 @@
             "extractor": {
                 "filetype": "fusion.json",
                 "timezone": "Europe/Berlin",
-                "locale": "en_GB.UTF-8",
+                "locale": "en_GB",
                 "encoding": null,
                 "parameters": null
             },

--- a/tests/test_dataschema/ts13_fusion_json.json
+++ b/tests/test_dataschema/ts13_fusion_json.json
@@ -37,7 +37,8 @@
                 "filetype": "fusion.json",
                 "timezone": "Europe/Berlin",
                 "locale": "en_GB.UTF-8",
-                "encoding": null
+                "encoding": null,
+                "parameters": null
             },
             "externaldate": null
         }

--- a/tests/test_dataschema/ts14_basic_csv.json
+++ b/tests/test_dataschema/ts14_basic_csv.json
@@ -31,7 +31,7 @@
             "extractor": {
                 "filetype": "basic.csv",
                 "encoding": null,
-                "locale": "de_DE.UTF-8",
+                "locale": "de_DE",
                 "timezone": "Europe/Zurich",
                 "parameters": {
                     "sep": ",",

--- a/tests/test_dataschema/ts14_basic_csv.json
+++ b/tests/test_dataschema/ts14_basic_csv.json
@@ -1,0 +1,47 @@
+{
+    "input": {
+        "version": "5.1",
+        "metadata": {
+            "provenance": {"type": "datagram_from_input"}
+        },
+        "step_defaults": {
+            "timezone": "UTC",
+            "locale": "en_GB.UTF-8"
+        },
+        "steps": [
+            {
+                "input": {"files": ["measurement.csv"]},
+                "extractor": {
+                    "filetype": "basic.csv",
+                    "locale": "de_DE.UTF-8",
+                    "timezone": "Europe/Zurich"
+                }
+            }
+        ]
+    },
+    "output": [
+        {
+            "input": {
+                "files": ["measurement.csv"],
+                "prefix": null,
+                "suffix": null,
+                "contains": null,
+                "exclude": null
+            },
+            "extractor": {
+                "filetype": "basic.csv",
+                "encoding": null,
+                "locale": "de_DE.UTF-8",
+                "timezone": "Europe/Zurich",
+                "parameters": {
+                    "sep": ",",
+                    "strip": null,
+                    "timestamp": null,
+                    "units": null
+                }
+            },
+            "tag": null,
+            "externaldate": null
+        }
+    ]
+}

--- a/tests/test_dataschema/ts15_example.json
+++ b/tests/test_dataschema/ts15_example.json
@@ -1,0 +1,43 @@
+{
+    "input": {
+        "version": "5.1",
+        "metadata": {
+            "provenance": {"type": "manual"}
+        },
+        "steps": [
+            {
+                "tag": "test_tag",
+                "input": {"folders": ["fol"], "suffix": ".txt"},
+                "extractor": {
+                    "filetype": "example",
+                    "timezone": "Europe/Zurich",
+                    "parameters": {"k": "v"}
+                },
+                "externaldate": {"using": {"filename": {"len": 10, "format": "%Y_%m_%d"}}}
+            }
+        ]
+    },
+    "output": [
+        {
+            "input": {
+                "files": ["fol"],
+                "prefix": null,
+                "suffix": ".txt",
+                "contains": null,
+                "exclude": null
+            },
+            "tag": "test_tag",
+            "extractor": {
+                "encoding": null,
+                "filetype": "example",
+                "locale": null,
+                "timezone": "Europe/Zurich",
+                "parameters": {"k": "v"}
+            },
+            "externaldate": {
+                "using": {"filename": {"len": 10, "format": "%Y_%m_%d"}},
+                "mode": "add"
+            }
+        }
+    ]
+}

--- a/versioneer.py
+++ b/versioneer.py
@@ -479,7 +479,9 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
     return stdout, process.returncode
 
 
-LONG_VERSION_PY["git"] = r'''
+LONG_VERSION_PY[
+    "git"
+] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build

--- a/versioneer.py
+++ b/versioneer.py
@@ -479,9 +479,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
     return stdout, process.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
This PR will implement `DataSchema-5.1`, which significantly simplifies the `DataSchema` as we move from `Parsers` towards `Extractors` in `yadg`.

- Each former parser now has an associated `extractor.FileType`, that is `basic.csv` for `basiccsv`, `FHI.csv` for `meascsv` and `example` (or `tomato.json`) for `dummy`.
- The parameters of an `Extractor` are now within that model; this really only applies to the CSV-based `Extractors`
- The `Union` of all supported `FileTypes` is now automatically generated within the module. This should reduce the number of places where a new `Extractor` needs to be defined, somewhat. 