### PR TITLE
`DataSchema`: Modify locale default behaviour in StepDefaults 5.0 and 5.1

### DIFF
--- a/src/dgbowl_schemas/yadg/dataschema_5_0/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_0/stepdefaults.py
@@ -35,5 +35,12 @@ class StepDefaults(BaseModel, extra="forbid"):
     @classmethod
     def locale_set_default(cls, v):
         if v is None:
-            v = ".".join(locale.getlocale())
+            for loc in (locale.getlocale(), locale.getlocale(locale.LC_NUMERIC)):
+                try:
+                    v = ".".join(loc)
+                    break
+                except TypeError:
+                    pass
+            else:
+                v = "en_GB.UTF-8"
         return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -36,12 +36,14 @@ class StepDefaults(BaseModel, extra="forbid"):
     @classmethod
     def locale_set_default(cls, v):
         if v is None:
-            for loc in (locale.getlocale(locale.LC_NUMERIC), locale.getlocale()):
+            for loc in (locale.getlocale(locale.LC_NUMERIC)[0], locale.getlocale()[0]):
                 try:
-                    v = str(Locale.parse(loc[0]))
+                    v = str(Locale.parse(loc))
                     break
                 except (TypeError, UnknownLocaleError):
                     pass
             else:
                 v = "en_GB"
+        else:
+            v = str(Locale.parse(v))
         return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -36,9 +36,12 @@ class StepDefaults(BaseModel, extra="forbid"):
     @classmethod
     def locale_set_default(cls, v):
         if v is None:
-            v = locale.getlocale(locale.LC_NUMERIC)[0]
-        try:
-            v = str(Locale.parse(v))
-        except (TypeError, UnknownLocaleError):
-            v = "en_GB"
+            for loc in (locale.getlocale(locale.LC_NUMERIC), locale.getlocale()):
+                try:
+                    v = str(Locale.parse(loc[0]))
+                    break
+                except (TypeError, UnknownLocaleError):
+                    pass
+            else:
+                v = "en_GB"
         return v

--- a/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
+++ b/src/dgbowl_schemas/yadg/dataschema_5_1/stepdefaults.py
@@ -35,15 +35,12 @@ class StepDefaults(BaseModel, extra="forbid"):
     @field_validator("locale")
     @classmethod
     def locale_set_default(cls, v):
-        if v is None:
-            for loc in (locale.getlocale(locale.LC_NUMERIC)[0], locale.getlocale()[0]):
-                try:
-                    v = str(Locale.parse(loc))
-                    break
-                except (TypeError, UnknownLocaleError):
-                    pass
-            else:
-                v = "en_GB"
+        for loc in (v, locale.getlocale(locale.LC_NUMERIC)[0], locale.getlocale()[0]):
+            try:
+                v = str(Locale.parse(loc))
+                break
+            except (TypeError, UnknownLocaleError):
+                pass
         else:
-            v = str(Locale.parse(v))
+            v = "en_GB"
         return v


### PR DESCRIPTION
Closes https://github.com/dgbowl/yadg/issues/177.

Previously, `DataSchema-5.0` would probe `LC_ALL` to get the default locale, and if unset, would crash. Now, we probe `LC_ALL` (which is often set on Windows), then `LC_NUMERIC` (which is often set on Linux and Mac), and then fall back to `en_GB.UTF-8`.

I have also modified `DataSchema-5.1` which previously only probed `LC_NUMERIC` to also probe `LC_ALL` if `LC_NUMERIC` is unset (as is the case on Windows). The default / fallback remains `en_GB`.